### PR TITLE
Uses correct option names on installation.

### DIFF
--- a/GuestUserPlugin.php
+++ b/GuestUserPlugin.php
@@ -39,9 +39,9 @@ class GuestUser extends Omeka_Plugin_Abstract
                 ";
 
         $db->query($sql);
-        set_option('guest_users_logged_in_text', '');
-        set_option('guest_users_login_text', 'Login');
-        set_option('guest_users_registration_text', 'Register');
+        set_option('guest_user_logged_in_text', '');
+        set_option('guest_user_login_text', 'Login');
+        set_option('guest_user_register_text', 'Register');
     }
 
 


### PR DESCRIPTION
The option names were different on installation than those used through the
plugin. This causes the default values to not appear in places like the
configuration form or the public theme header.

I opted to change the names in the installation hook instead of changing them
elsewhere and adding a migration, since the plugin has yet to be tagged and
released. Users will need to uninstall and reinstall the plugin to get the
correct options, however.
