### PR TITLE
Missing ACL. Redundant ReCaptcha on update-account page.

### DIFF
--- a/GuestUserPlugin.php
+++ b/GuestUserPlugin.php
@@ -90,6 +90,12 @@ class GuestUserPlugin extends Omeka_Plugin_AbstractPlugin
     {
         $acl = $args['acl'];
         $acl->addRole(new Zend_Acl_Role('guest'), null);
+
+        if (!$acl->has('GuestUser_User')) {
+            $acl->addResource('GuestUser_User');
+        }
+        $acl->allow(null, 'GuestUser_User', array('login', 'register', 'confirm', 'stale-token'));
+        $acl->allow('guest', 'GuestUser_User', array('me', 'update-account'));
     }
 
     public function hookConfig($args)

--- a/controllers/UserController.php
+++ b/controllers/UserController.php
@@ -87,6 +87,8 @@ class GuestUser_UserController extends Omeka_Controller_AbstractActionController
         $user = current_user();
 
         $form = $this->_getForm(array('user'=>$user));
+        // do not include captcha when updating account - no bot should be able to access this page anyway
+        $form->removeElement('captcha');
         $form->getElement('new_password')->setLabel(__("New Password"));
         $form->getElement('new_password')->setRequired(false);
         $form->getElement('new_password_confirm')->setRequired(false);


### PR DESCRIPTION
It feels wrong to include ReCaptcha when updating account, since we require current password. Added ACL so that it's *impossible* for bots to come there