### PR TITLE
Remove short registration info

### DIFF
--- a/GuestUserPlugin.php
+++ b/GuestUserPlugin.php
@@ -10,7 +10,6 @@ class GuestUserPlugin extends Omeka_Plugin_AbstractPlugin
         'install',
         'uninstall',
         'define_acl',
-        'public_header',
         'public_head',
         'admin_theme_header',
         'config',
@@ -120,21 +119,6 @@ class GuestUserPlugin extends Omeka_Plugin_AbstractPlugin
     public function hookPublicHead($args)
     {
         queue_css_file('guest-user');
-        queue_js_file('guest-user');
-    }
-
-    public function hookPublicHeader($args)
-    {
-        $html = "<div id='guest-user-register-info'>";
-        $user = current_user();
-        if(!$user) {
-            $shortCapabilities = get_option('guest_user_short_capabilities');
-            if($shortCapabilities != '') {
-                $html .= $shortCapabilities;
-            }
-        }
-        $html .= "</div>";
-        echo $html;
     }
 
     public function hookBeforeSaveUser($args)

--- a/config_form.php
+++ b/config_form.php
@@ -2,7 +2,7 @@
 
 <div class="field">
     <div class="two columns alpha">
-        <label><?php echo __('Registration Features'); ?></label>    
+        <label><?php echo __('Registration Features'); ?></label>
     </div>
     <div class="inputs five columns omega" >
         <p class='explanation'><?php echo __("Add some text to the registration screen so people will know what they get for registering.
@@ -12,55 +12,41 @@
         <div class="input-block">
             <textarea name="guest_user_capabilities" ><?php echo get_option('guest_user_capabilities'); ?></textarea>
         </div>
-
     </div>
 </div>
 
 <div class="field">
     <div class="two columns alpha">
-        <label><?php echo __("Short Registration Features"); ?></label>    
+        <label><?php echo __("Dashboard Label"); ?></label>
     </div>
-    <div class="inputs five columns omega" >
-        <p class='explanation'><?php echo __("Add a shorter version to use as a dropdown from the user bar. If empty, no dropdown will appear."); ?>
-        </p>        
-        <div class="input-block">
-            <textarea name="guest_user_short_capabilities" ><?php echo get_option('guest_user_short_capabilities'); ?></textarea>
-        </div>
-    </div>
-</div>
-
-<div class="field">
-    <div class="two columns alpha">
-        <label><?php echo __("Dashboard Label"); ?></label>    
-    </div>    
     <div class="inputs five columns omega">
         <p class='explanation'><?php echo __("The text to use for the label on the user's dashboard"); ?></p>
-        <div class="input-block">        
-            <input name="guest_user_dashboard_label" type="text" value="<?php echo get_option('guest_user_dashboard_label'); ?>" />        
+        <div class="input-block">
+            <input name="guest_user_dashboard_label" type="text" value="<?php echo get_option('guest_user_dashboard_label'); ?>" />
         </div>
     </div>
 </div>
 
 <div class="field">
     <div class="two columns alpha">
-        <label><?php echo __("Login Text"); ?></label>    
-    </div>    
+        <label><?php echo __("Login Text"); ?></label>
+    </div>
     <div class="inputs five columns omega">
         <p class='explanation'><?php echo __("The text to use for the 'Login' link in the user bar"); ?></p>
-        <div class="input-block">        
-        <input name="guest_user_login_text" type="text" value="<?php echo get_option('guest_user_login_text'); ?>" />        
+        <div class="input-block">
+        <input name="guest_user_login_text" type="text" value="<?php echo get_option('guest_user_login_text'); ?>" />
         </div>
     </div>
 </div>
-        
+
 <div class="field">
     <div class="two columns alpha">
-        <label><?php echo __("Register Text"); ?></label>    
-    </div>    
+        <label><?php echo __("Register Text"); ?></label>
+    </div>
     <div class="inputs five columns omega">
         <p class='explanation'><?php echo __("The text to use for the 'Register' link in the user bar."); ?></p>
-        <div class="input-block">        
-            <input name="guest_user_register_text" type="text" value="<?php echo get_option('guest_user_register_text'); ?>" />        
+        <div class="input-block">
+            <input name="guest_user_register_text" type="text" value="<?php echo get_option('guest_user_register_text'); ?>" />
         </div>
     </div>
 </div>
@@ -68,11 +54,11 @@
 
 <div class="field">
     <div class="two columns alpha">
-        <label><?php echo __("Allow open registration?"); ?></label>    
+        <label><?php echo __("Allow open registration?"); ?></label>
     </div>
     <div class="inputs five columns omega">
         <p class="explanation"><?php echo __("Allow guest user registration without administrator approval?"); ?></p>
-        <div class="input-block">        
+        <div class="input-block">
             <?php
                 $checked = ( get_option('guest_user_open') == 1) ;
                 if($checked) {
@@ -80,27 +66,27 @@
                 } else {
                     $options = array();
                 }
-                echo $view->formCheckbox('guest_user_open', null, $options);                
+                echo $view->formCheckbox('guest_user_open', null, $options);
             ?>
         </div>
     </div>
 </div>
-        
-        
+
+
 <div class="field">
     <div class="two columns alpha">
-        <label><?php echo __("Allow instant access?"); ?></label>    
+        <label><?php echo __("Allow instant access?"); ?></label>
     </div>
     <div class="inputs five columns omega">
         <p class="explanation"><?php echo __("Allow instant access for 20 minutes for new users"); ?></p>
-        <div class="input-block">        
+        <div class="input-block">
             <?php
                 $checked = ( get_option('guest_user_instant_access') == 1 );
                 if($checked) {
                     $options = array('checked'=>'checked');
                 } else {
                     $options = array();
-                }            
+                }
                 echo $view->formCheckbox('guest_user_instant_access', null, $options);
             ?>
         </div>
@@ -110,11 +96,11 @@
 <?php if(get_option('recaptcha_public_key') && get_option('recaptcha_private_key')): ?>
 <div class="field">
     <div class="two columns alpha">
-        <label><?php echo __("Require ReCaptcha?"); ?></label>    
+        <label><?php echo __("Require ReCaptcha?"); ?></label>
     </div>
     <div class="inputs five columns omega">
         <p class="explanation"><?php echo __("Check this to require passing a ReCaptcha test when registering"); ?></p>
-        <div class="input-block">        
+        <div class="input-block">
             <?php
                 $checked = ( get_option('guest_user_recaptcha') == 1);
                 if($checked) {
@@ -123,7 +109,7 @@
                     $options = array();
                 }
                 echo $view->formCheckbox('guest_user_recaptcha', null, $options);
-            ?>           
+            ?>
         </div>
     </div>
 </div>

--- a/views/public/css/guest-user.css
+++ b/views/public/css/guest-user.css
@@ -17,13 +17,13 @@
         border-radius: 3px;
         font-size: 14px;
         margin-bottom: 20px;
-        padding: .5em;            
+        padding: .5em;
     }
 
 .success {
     color: #729108;
 }
-    
+
 .error, .alert {
     color: #914E33;
 }
@@ -61,19 +61,6 @@ h2.guest-user-widget-label {
     text-transform: uppercase;
 }
 
-div#guest-user-register-info {
-    background: rgba(0,0,0,0.75);    
-    color: #fff;
-    position:absolute;
-    right: 0;
-    top: 40px;
-    font-family:Arvo, serif !important;
-    font-size: 12px;
-    width: 250px;
-    display: none;
-    padding: 3px;
-}
-
 div.guest-user-widget {
     border: 1px solid rgba(0,0,0,.3);
     margin: 0 1.5em 1.5em 0;
@@ -95,5 +82,4 @@ div.guest-user-widget-odd {
 
 p.explanation {
     margin-top: 0px;
-    
 }

--- a/views/public/javascripts/guest-user.js
+++ b/views/public/javascripts/guest-user.js
@@ -1,4 +1,0 @@
-jQuery('document').ready(function() {
-    var adminBarHeight = jQuery('#admin-bar');
-    jQuery('#guest-user-register-info').css('top', adminBarHeight + 'px');
-});


### PR DESCRIPTION
This could solve #22 
Based on content length and device, it may overlap search box and cannot be closed...
I didn't see big gain in displaying it, the registration features are sufficient for me. 