### PR TITLE
New password bugfix

### DIFF
--- a/controllers/UserController.php
+++ b/controllers/UserController.php
@@ -114,7 +114,9 @@ class GuestUser_UserController extends Omeka_Controller_AbstractActionController
             return;
         }
 
-        $user->setPassword($_POST['new_password']);
+        if (trim($_POST['new_password'])) {
+            $user->setPassword($_POST['new_password']);
+        }
         $user->setPostData($_POST);
         try {
             $user->save($_POST);


### PR DESCRIPTION
Without check if the new password was specified (has length), it is resetting the current password (probably into empty string) and it's impossible to log in again.

Steps to repro:
1. Login as guest user
2. Go to My Account > Update account info and password
3. Enter current password and submit
4. Logout
5. Try to login with your current password again